### PR TITLE
Explicitly link with `-no-pie`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@
 all: injector
 
 injector: injector.o
-	$(CC) $(CFLAGS) $< -O3 -Wall -l:libcapstone.a -o $@ -pthread
+	$(CC) $(CFLAGS) $< -O3 -Wall -no-pie -l:libcapstone.a -o $@ -pthread
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c $< -o $@ -Wall


### PR DESCRIPTION
Tested on Debian Sid/unstable with Debian’s package
[libcapstone-dev](https://packages.debian.org/sid/libcapstone-dev) 3.0.4-1 installed.