### PR TITLE
summarize: fix collapse all

### DIFF
--- a/summarize.py
+++ b/summarize.py
@@ -814,6 +814,7 @@ if __name__ == "__main__":
             collapse_all(c)
             (summary, lookup) = build_instruction_summary(c)
             textbox.text = summary
+            textbox.scroll_top()
         elif key == ord('g'):
             textbox.scroll_top()
         elif key == ord('G'):


### PR DESCRIPTION
With the current implementation, 'collapse all' (shortcut 'H')
crashes with the following error when anything other than the
top-level item is selected (for this particular key, the first
sub-item was selected):

```
Traceback (most recent call last):
  File "./summarize.py", line 753, in <module>
    draw_infobox(gui, lookup[textbox.selected_index])
KeyError: 1
```

Fix it by scrolling to the top whenever collapsing the whole tree.