### PR TITLE
Fix code not working when default python is python3

### DIFF
--- a/sifter.py
+++ b/sifter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 # instruction injector frontend
 

--- a/summarize.py
+++ b/summarize.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 # we had a much more automated and intelligent approach to reducing the log, but
 # could not come up with a reasonable way to differentiate between a modr/m byte


### PR DESCRIPTION
Some linux distributions (in particular arch linux) use python 3 as their default. This means that `/usr/bin/python` is a symlink to `/usr/bin/python3`. Your code however is not compatible with python3. A simple fix, which should maintain compatibility with other distributions is to explicitly start the program with python2. I have provided the necessary change for you.